### PR TITLE
feat(smoke-test): add append-timestamp script with tests

### DIFF
--- a/scripts/__tests__/append-timestamp.test.mjs
+++ b/scripts/__tests__/append-timestamp.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for append-timestamp.mjs
+ *
+ * Tests: as-001-append-timestamp (sg-smoke-test-e2e)
+ *
+ * Run with: node --test scripts/__tests__/append-timestamp.test.mjs
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { appendTimestamp } from '../append-timestamp.mjs';
+
+describe('appendTimestamp - as-001: Append ISO Timestamp', () => {
+  let testDir;
+  let filePath;
+
+  beforeEach(() => {
+    // Arrange - create a unique temp directory per test
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(tmpdir(), `smoke-test-${id}`);
+    mkdirSync(testDir, { recursive: true });
+    filePath = join(testDir, 'SMOKE_TEST.md');
+  });
+
+  afterEach(() => {
+    // Cleanup
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  });
+
+  describe('AC1: appends ISO 8601 timestamp line', () => {
+    it('should append a line with an ISO 8601 timestamp (as-001 AC1)', () => {
+      // Arrange
+      const fixedDate = new Date('2026-02-15T12:00:00Z');
+      writeFileSync(filePath, '# Smoke Test Log\n\n', 'utf-8');
+
+      // Act
+      appendTimestamp(filePath, fixedDate);
+
+      // Assert
+      const content = readFileSync(filePath, 'utf-8');
+      assert.ok(content.includes('- 2026-02-15T12:00:00Z'), `Expected timestamp line, got:\n${content}`);
+    });
+
+    it('should produce a valid ISO 8601 timestamp format (as-001 AC1)', () => {
+      // Arrange
+      writeFileSync(filePath, '# Smoke Test Log\n\n', 'utf-8');
+
+      // Act
+      appendTimestamp(filePath);
+
+      // Assert
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.trim().split('\n');
+      const lastLine = lines[lines.length - 1];
+      // Match pattern: - YYYY-MM-DDTHH:MM:SSZ
+      assert.match(lastLine, /^- \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/, `Timestamp line should match ISO 8601 format, got: ${lastLine}`);
+    });
+  });
+
+  describe('AC2: creates file with header when it does not exist', () => {
+    it('should create SMOKE_TEST.md with header if it does not exist (as-001 AC2)', () => {
+      // Arrange - file does not exist
+      assert.ok(!existsSync(filePath), 'File should not exist before test');
+      const fixedDate = new Date('2026-02-15T12:00:00Z');
+
+      // Act
+      appendTimestamp(filePath, fixedDate);
+
+      // Assert
+      assert.ok(existsSync(filePath), 'File should be created');
+      const content = readFileSync(filePath, 'utf-8');
+      assert.ok(content.startsWith('# Smoke Test Log\n\n'), `File should start with header, got:\n${content}`);
+      assert.ok(content.includes('- 2026-02-15T12:00:00Z'), `File should contain timestamp, got:\n${content}`);
+    });
+  });
+
+  describe('AC3: preserves existing content', () => {
+    it('should preserve existing content when appending (as-001 AC3)', () => {
+      // Arrange
+      const existingContent = '# Smoke Test Log\n\n- 2026-02-14T10:00:00Z\n';
+      writeFileSync(filePath, existingContent, 'utf-8');
+      const fixedDate = new Date('2026-02-15T12:00:00Z');
+
+      // Act
+      appendTimestamp(filePath, fixedDate);
+
+      // Assert
+      const content = readFileSync(filePath, 'utf-8');
+      assert.ok(content.startsWith('# Smoke Test Log\n\n'), 'Header should be preserved');
+      assert.ok(content.includes('- 2026-02-14T10:00:00Z'), 'Existing timestamp should be preserved');
+      assert.ok(content.includes('- 2026-02-15T12:00:00Z'), 'New timestamp should be appended');
+    });
+
+    it('should append multiple timestamps in order (as-001 AC3)', () => {
+      // Arrange
+      writeFileSync(filePath, '# Smoke Test Log\n\n', 'utf-8');
+      const date1 = new Date('2026-02-15T10:00:00Z');
+      const date2 = new Date('2026-02-15T11:00:00Z');
+      const date3 = new Date('2026-02-15T12:00:00Z');
+
+      // Act
+      appendTimestamp(filePath, date1);
+      appendTimestamp(filePath, date2);
+      appendTimestamp(filePath, date3);
+
+      // Assert
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.trim().split('\n');
+      const timestampLines = lines.filter((l) => l.startsWith('- '));
+      assert.equal(timestampLines.length, 3, `Expected 3 timestamp lines, got ${timestampLines.length}`);
+      assert.equal(timestampLines[0], '- 2026-02-15T10:00:00Z');
+      assert.equal(timestampLines[1], '- 2026-02-15T11:00:00Z');
+      assert.equal(timestampLines[2], '- 2026-02-15T12:00:00Z');
+    });
+  });
+});

--- a/scripts/append-timestamp.mjs
+++ b/scripts/append-timestamp.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * Append an ISO 8601 timestamp to SMOKE_TEST.md.
+ *
+ * - If SMOKE_TEST.md does not exist, creates it with a header first.
+ * - Appends a line `- <ISO timestamp>` to the file.
+ *
+ * Implements: as-001-append-timestamp (sg-smoke-test-e2e)
+ */
+
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HEADER = '# Smoke Test Log\n\n';
+
+/**
+ * Append an ISO timestamp line to the given file path.
+ * Creates the file with a header if it does not exist.
+ *
+ * @param {string} filePath - Absolute path to SMOKE_TEST.md
+ * @param {Date} [now] - Optional date for testing; defaults to new Date()
+ */
+export function appendTimestamp(filePath, now = new Date()) {
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, HEADER, 'utf-8');
+  }
+
+  const timestamp = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  appendFileSync(filePath, `- ${timestamp}\n`, 'utf-8');
+}
+
+// CLI entry point
+const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+if (isDirectRun) {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const filePath = join(root, 'SMOKE_TEST.md');
+  appendTimestamp(filePath);
+  console.log(`Timestamp appended to ${filePath}`);
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/append-timestamp.mjs` — exports `appendTimestamp()` that appends an ISO 8601 timestamp line to `SMOKE_TEST.md`, creating the file with a header if it doesn't exist
- Adds `scripts/__tests__/append-timestamp.test.mjs` — 5 unit tests using `node:test` covering all 3 acceptance criteria from `as-001-append-timestamp`

## Spec Group

`sg-smoke-test-e2e` → atomic spec `as-001-append-timestamp`

**AC Coverage**: 100% (AC1, AC2, AC3)

| AC | Description | Tests |
|----|-------------|-------|
| AC1 | Appends ISO 8601 timestamp line | 2 tests |
| AC2 | Creates file with header if missing | 1 test |
| AC3 | Preserves existing content | 2 tests |

## Test plan

- [x] `node --test scripts/__tests__/append-timestamp.test.mjs` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)